### PR TITLE
add anonymousId at comment responses, modify totalcomment notificatio…

### DIFF
--- a/src/main/java/community/mingle/app/src/comment/CommentController.java
+++ b/src/main/java/community/mingle/app/src/comment/CommentController.java
@@ -33,10 +33,10 @@ public class CommentController {
      */
     @Operation(summary = "4.1 createTotalComment api", description = "4.1 전체 게시판 댓글 작성 api")
     @PostMapping("/total")
-    public BaseResponse<Long> createTotalComment(@RequestBody PostTotalCommentRequest postTotalCommentRequest) {
+    public BaseResponse<PostTotalCommentResponse> createTotalComment(@RequestBody PostTotalCommentRequest postTotalCommentRequest) {
         try {
-            Long id = commentService.createTotalComment(postTotalCommentRequest);
-            return new BaseResponse<>(id);
+            PostTotalCommentResponse result = commentService.createTotalComment(postTotalCommentRequest);
+            return new BaseResponse<>(result);
 
         } catch (BaseException exception) {
             return new BaseResponse<>(exception.getStatus());
@@ -49,10 +49,10 @@ public class CommentController {
      */
     @Operation(summary = "4.2 createUnivComment api", description = "4.2 학교 게시판 댓글 작성 api")
     @PostMapping("/univ")
-    public BaseResponse<Long> createUnivComment(@RequestBody PostUnivCommentRequest univCommentRequest) {
+    public BaseResponse<PostUnivCommentResponse> createUnivComment(@RequestBody PostUnivCommentRequest univCommentRequest) {
         try {
-            Long id = commentService.createUnivComment(univCommentRequest);
-            return new BaseResponse<>(id);
+            PostUnivCommentResponse result = commentService.createUnivComment(univCommentRequest);
+            return new BaseResponse<>(result);
 
         } catch (BaseException exception) {
             return new BaseResponse<>(exception.getStatus());

--- a/src/main/java/community/mingle/app/src/comment/CommentRepository.java
+++ b/src/main/java/community/mingle/app/src/comment/CommentRepository.java
@@ -54,7 +54,7 @@ public class CommentRepository {
          */
         List<TotalComment> totalComments = post.getTotalPostComments();
 
-        TotalComment totalCommentWithMaxAnonymousId = null;
+        TotalComment totalCommentWithMaxAnonymousId;
         try {  //게시물에서 제일 큰 id를 찾은 후 +1 한 id 를 내 댓글에 새로운 anonymousId 로 부여
             totalCommentWithMaxAnonymousId = totalComments.stream()
                     .max(Comparator.comparingLong(TotalComment::getAnonymousId))//nullPointerException
@@ -69,9 +69,8 @@ public class CommentRepository {
     }
 
 
-    public TotalComment saveTotalComment (TotalComment comment) {
+    public void saveTotalComment (TotalComment comment) {
         em.persist(comment);
-        return comment;
     }
 
 

--- a/src/main/java/community/mingle/app/src/comment/model/PostTotalCommentResponse.java
+++ b/src/main/java/community/mingle/app/src/comment/model/PostTotalCommentResponse.java
@@ -1,0 +1,20 @@
+package community.mingle.app.src.comment.model;
+
+import community.mingle.app.src.domain.Total.TotalComment;
+import lombok.Getter;
+
+@Getter
+public class PostTotalCommentResponse {
+    Long commentId;
+    String nickname;
+
+    public PostTotalCommentResponse(Long anonymousId, TotalComment totalComment) {
+        this.commentId = totalComment.getId();
+        if (anonymousId == null) {
+            this.nickname = totalComment.getMember().getNickname();
+        } else{
+            this.nickname = "익명 " + anonymousId;
+        }
+
+    }
+}

--- a/src/main/java/community/mingle/app/src/comment/model/PostUnivCommentResponse.java
+++ b/src/main/java/community/mingle/app/src/comment/model/PostUnivCommentResponse.java
@@ -1,0 +1,21 @@
+package community.mingle.app.src.comment.model;
+
+import community.mingle.app.src.domain.Univ.UnivComment;
+import lombok.Getter;
+
+@Getter
+public class PostUnivCommentResponse {
+
+    Long commentId;
+    String nickname;
+
+    public PostUnivCommentResponse(Long anonymousId, UnivComment univComment) {
+        this.commentId = univComment.getId();
+        if (anonymousId == null) {
+            this.nickname = univComment.getMember().getNickname();
+        } else{
+            this.nickname = "익명 " + anonymousId;
+        }
+
+    }
+}


### PR DESCRIPTION
- 4.1, 4.2 댓글 작성 api 리턴 시 PostTotalCommentResponse, PostUnivCommentResponse 클래스를 하여 anonymousId까지 함께 반환하도록 수정
- totalcomment notification 로직에서 parentcCommentId와 mentionId가 null일 경우를 고려 안하여 NPE 뜨던 부분 수정
- univcomment notification 로직에서 mentionId가 null일 경우를 고려 안하여 NPE 뜨던 부분 수정