### PR TITLE
TAS-103-불타오르는-전체-게시글-리스트-간헐적-500에러

### DIFF
--- a/src/main/java/community/mingle/app/src/post/model/PostListDTO.java
+++ b/src/main/java/community/mingle/app/src/post/model/PostListDTO.java
@@ -17,7 +17,6 @@ import java.util.Objects;
 import java.util.stream.Collectors;
 
 import static community.mingle.app.config.DateTimeConverter.convertLocaldatetimeToTime;
-import static community.mingle.app.config.DateTimeConverter.convertStringToLocalDateTime;
 import static community.mingle.app.src.domain.PostStatus.DELETED;
 import static community.mingle.app.src.domain.PostStatus.REPORTED;
 
@@ -34,6 +33,8 @@ public class PostListDTO {
     private final boolean isAdmin;
     private final BoardType boardType;
     private final CategoryType categoryType;
+    @JsonIgnore
+    private final LocalDateTime createdAtInLocalDateTime;
     private String title;
     private String contents;
     private String nickname;
@@ -72,6 +73,7 @@ public class PostListDTO {
         this.isAdmin = totalPost.getMember().getRole().equals(UserRole.ADMIN);
         this.boardType = BoardType.광장;
         this.categoryType = CategoryType.valueOf(totalPost.getCategory().getName());
+        this.createdAtInLocalDateTime = totalPost.getCreatedAt();
     }
 
 
@@ -113,12 +115,14 @@ public class PostListDTO {
         this.createdAt = convertLocaldatetimeToTime(univPost.getCreatedAt());
         this.isAdmin = univPost.getMember().getRole().equals(UserRole.ADMIN);
         this.boardType = BoardType.잔디밭;
+        String c = univPost.getCategory().getName();
         this.categoryType = CategoryType.valueOf(univPost.getCategory().getName());
+        this.createdAtInLocalDateTime = univPost.getCreatedAt();
     }
 
     @JsonIgnore
     public LocalDateTime getCreatedAtDateTime() {
-        return convertStringToLocalDateTime(createdAt);
+        return createdAtInLocalDateTime;
     }
 
 }


### PR DESCRIPTION
Comparison method violates its general contract!
- 기존에는 6개월 전, 5개월 전 과 같은 String으로 된 createdAt을 LocalDateTime.now()와 비교해 LocalDateTime type으로 convert 한 후 비교했는데 이 경우 같은 5개월 전 게시물을 비교하면 같은 createdAt 값이 나올 수도 있었음

dto 필드에 createdAtInLocalDateTme을 추가하고 해당 포스트의 LocalDateTime을 직접 넣어서 비교한 후 jsonignore로 클라이언트에는 objectmapper가 mapping하지 않도록 했음