### PR TITLE
TAS-244 장터-사진-없으면-등록-안되게-하기

### DIFF
--- a/src/main/java/community/mingle/app/config/BaseException.java
+++ b/src/main/java/community/mingle/app/config/BaseException.java
@@ -7,6 +7,6 @@ import lombok.Setter;
 @Getter
 @Setter
 @AllArgsConstructor
-public class BaseException extends Exception {
+public class BaseException extends RuntimeException {
     private BaseResponseStatus status;
 }

--- a/src/main/java/community/mingle/app/src/item/ItemService.java
+++ b/src/main/java/community/mingle/app/src/item/ItemService.java
@@ -69,7 +69,7 @@ public class ItemService {
             Item item = Item.createItemPost(member, createItemRequest);
             Long id = itemRepository.save(item);
             List<String> fileNameList;
-            if (createItemRequest.getMultipartFile() == null || createItemRequest.getMultipartFile().isEmpty()) {
+            if (createItemRequest.getMultipartFile() == null || createItemRequest.getMultipartFile().isEmpty() || createItemRequest.getMultipartFile().get(0).getSize() == 0) {
                 throw new BaseException(IMG_UPLOAD_REQUIRED);
             } else {
                 try {
@@ -85,6 +85,7 @@ public class ItemService {
             }
             return new CreateItemResponse(id);
         } catch (Exception e) {
+            e.printStackTrace();
             throw new BaseException(CREATE_FAIL_POST);
         }
     }


### PR DESCRIPTION
- @transactional 은 unchecked Exception (runtime Excepiton) 일때만 rollback이 됨
- 기존 baseException 은 Exception을 상속받고 있었음 which is checked Exception
- 따라서 baseException을 RuntimeException을 상속하도록 함